### PR TITLE
[WIP] Extract peaks from Audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Thumbs.db
 /dist
 
 /coverage
+
+# ignore files generated from makefile
+extra/**/*.o
+extra/**/pex

--- a/extra/Makefile
+++ b/extra/Makefile
@@ -1,0 +1,9 @@
+all: pex
+
+pex:
+	cd media_processor && make && mv pex ../pex
+
+.PHONY: clean
+
+clean:
+	rm pex

--- a/extra/media_processor/Makefile
+++ b/extra/media_processor/Makefile
@@ -1,0 +1,31 @@
+ffmpeg_cflags = $(shell pkg-config --cflags libavformat libavcodec libavutil libswresample)
+ffmpeg_libs = $(shell pkg-config --libs libavformat libavcodec libavutil libswresample)
+
+CXXFLAGS = -std=c++14 $(ffmpeg_cflags) -O2
+LIBS = $(ffmpeg_libs)
+
+OBJECTS = .ffmpeg_error.o .keyframe_extractor.o .main.o .media_file.o .media_processor.o .peak_extractor.o .stream_processor.o
+
+all: $(OBJECTS)
+	g++ $(CXXFLAGS) -o pex $(OBJECTS) $(LIBS)
+
+.ffmpeg_error.o: ffmpeg_error.cpp ffmpeg_error.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.keyframe_extractor.o: keyframe_extractor.cpp keyframe_extractor.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.main.o: main.cpp media_processor.hpp media_file.hpp peak_extractor.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.media_file.o: media_file.cpp media_file.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.media_processor.o: media_processor.cpp media_processor.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.peak_extractor.o: peak_extractor.cpp peak_extractor.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+.stream_processor.o: stream_processor.cpp stream_processor.hpp
+	g++ -c $(CXXFLAGS) $< -o $@
+
+.PHONY: clean
+
+clean:
+	rm $(OBJECTS)
+	rm pex

--- a/extra/media_processor/ffmpeg_error.cpp
+++ b/extra/media_processor/ffmpeg_error.cpp
@@ -1,0 +1,22 @@
+#include "ffmpeg_error.hpp"
+
+extern "C"
+{
+#include <libavutil/avutil.h>
+}
+
+std::string makeErrorMessage(int error)
+{
+    char error_buf[AV_ERROR_MAX_STRING_SIZE];
+    av_strerror(error, error_buf, AV_ERROR_MAX_STRING_SIZE);
+    return std::string(error_buf);
+}
+
+FFmpegError::FFmpegError(int error) :
+    ErrorMessage(makeErrorMessage(error))
+{ }
+
+const char *FFmpegError::what() const noexcept
+{
+    return ErrorMessage.c_str();
+}

--- a/extra/media_processor/ffmpeg_error.hpp
+++ b/extra/media_processor/ffmpeg_error.hpp
@@ -1,0 +1,25 @@
+#ifndef ffmpeg_error_hpp_INCLUDED
+#define ffmpeg_error_hpp_INCLUDED
+
+#include <exception>
+#include <string>
+
+class FFmpegError : public std::exception
+{
+    std::string ErrorMessage;
+
+public:
+    FFmpegError(int error);
+
+    FFmpegError(const std::string &errorMessage) :
+        std::exception(),
+        ErrorMessage(errorMessage)
+    { }
+
+    virtual ~FFmpegError() { }
+
+    virtual const char *what() const noexcept override;
+};
+
+#endif // ffmpeg_error_hpp_INCLUDED
+

--- a/extra/media_processor/keyframe_extractor.cpp
+++ b/extra/media_processor/keyframe_extractor.cpp
@@ -1,0 +1,68 @@
+#include "keyframe_extractor.hpp"
+#include "ffmpeg_error.hpp"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/opt.h>
+}
+
+#include <iostream>
+
+KeyFrameExtractor::KeyFrameExtractor(AVStream *stream) :
+    StreamDecoder(stream)
+{
+    if(av_opt_set(CodecCtx, "skip_frame", "nokey", 0) < 0)
+    {
+        throw FFmpegError("Sanity check, could not set skip_frame option");
+    }
+    Frame = av_frame_alloc();
+    if(!Frame)
+    {
+        throw FFmpegError("Could not allocate frame");
+    }
+    TimeBase = av_q2d(stream->time_base);
+    std::cout << "Start time (s): " << (stream->start_time * TimeBase) << std::endl;
+}
+
+KeyFrameExtractor::~KeyFrameExtractor()
+{
+    av_frame_free(&Frame);
+}
+
+void KeyFrameExtractor::push_packet(const AVPacket &pkt)
+{
+    int res = avcodec_send_packet(CodecCtx, &pkt);
+
+    if(res == AVERROR_EOF)
+    {
+        std::cout << "Done";
+    }
+    else if(res == AVERROR(EINVAL))
+    {
+        throw FFmpegError(res);
+    }
+
+    // Ok
+    while(avcodec_receive_frame(CodecCtx, Frame) == 0)
+    {
+        //if(Frame->key_frame == 0) std::cout << "No keyframe" << std::endl;
+        TimePoints.push_back(av_frame_get_best_effort_timestamp(Frame) * TimeBase * 1000.0);
+        //av_frame_unref(frame);
+    }
+   
+
+}
+
+void KeyFrameExtractor::processing_finished()
+{
+    // Let's flush the decoder
+    avcodec_send_packet(CodecCtx, nullptr);
+    while(avcodec_receive_frame(CodecCtx, Frame) == 0)
+    {
+        //if(Frame->key_frame == 0) std::cout << "No keyframe" << std::endl;
+        TimePoints.push_back(av_frame_get_best_effort_timestamp(Frame) * TimeBase * 1000.0);
+        //av_frame_unref(frame);
+    }
+}

--- a/extra/media_processor/keyframe_extractor.hpp
+++ b/extra/media_processor/keyframe_extractor.hpp
@@ -1,0 +1,30 @@
+#ifndef keyframe_extractor_hpp_INCLUDED
+#define keyframe_extractor_hpp_INCLUDED
+
+#include "stream_processor.hpp"
+#include <vector>
+
+struct AVFrame;
+
+class KeyFrameExtractor : public StreamDecoder
+{
+    std::vector<int> TimePoints;
+    AVFrame *Frame;
+    double TimeBase;
+public:
+    KeyFrameExtractor(AVStream *stream);
+
+    virtual ~KeyFrameExtractor();
+
+    virtual void push_packet(const AVPacket &pkt) override;
+
+    virtual void processing_finished() override;
+
+    const std::vector<int> &timePointsMs() const
+    {
+        return TimePoints;
+    }
+};
+
+#endif // keyframe_extractor_hpp_INCLUDED
+

--- a/extra/media_processor/main.cpp
+++ b/extra/media_processor/main.cpp
@@ -1,0 +1,51 @@
+#include "media_file.hpp"
+#include "media_processor.hpp"
+#include "peak_extractor.hpp"
+#include "ffmpeg_error.hpp"
+
+#include <fstream>
+
+int main(int argc, char *argv[])
+{
+    if(argc < 3) {
+        return 1;
+    }
+
+    av_register_all();
+
+    const char *input_filename = argv[1];
+    const char *output_filename = argv[2];
+
+        MediaFile media {input_filename};
+
+        const auto best_audio_stream = media.best_stream(AVMEDIA_TYPE_AUDIO);
+
+        if(best_audio_stream == media.end())
+        {
+            // There is no audio stream
+            return 2;
+        }
+
+
+        MediaProcessor processor {media};
+
+        int sample_rate = (*best_audio_stream)->codecpar->sample_rate;
+        int samples_per_peak = sample_rate / 100;
+        PeakExtractor peak_extractor {*best_audio_stream, samples_per_peak};
+        processor.addStreamProcessors(&peak_extractor);
+        processor.startProcessing();
+
+
+        std::ofstream file{output_filename};
+
+        file << sample_rate << "\n";
+        file << samples_per_peak;
+
+        for(const auto &peak : peak_extractor.peaks())
+        {
+            file << "\n";
+            file << peak.Min << "\n" << peak.Max;
+        }
+
+    return 0;
+}

--- a/extra/media_processor/media_file.cpp
+++ b/extra/media_processor/media_file.cpp
@@ -1,0 +1,57 @@
+#include "media_file.hpp"
+#include "ffmpeg_error.hpp"
+#include "stream_processor.hpp"
+
+MediaFile::MediaFile(const char *filename) :
+    FormatCtx(nullptr)
+{
+    // Open the input file
+    int result = avformat_open_input(&FormatCtx, filename, nullptr, nullptr);
+    if(result < 0)
+    {
+        FormatCtx = nullptr;
+        throw FFmpegError(result);
+    }
+
+    // Retrieve stream informations
+    result = avformat_find_stream_info(FormatCtx, nullptr);
+    if(result < 0)
+    {
+        // Cleanup data
+        avformat_close_input(&FormatCtx);
+        FormatCtx = nullptr;
+
+        throw FFmpegError(result);
+    }
+}
+
+MediaFile::MediaFile(const std::string &filename) :
+    MediaFile(filename.c_str())
+{ }
+
+MediaFile::~MediaFile()
+{
+    avformat_close_input(&FormatCtx);
+}
+
+AVStream **MediaFile::begin()
+{
+    return FormatCtx->streams;
+}
+
+AVStream **MediaFile::end()
+{
+    return FormatCtx->streams + FormatCtx->nb_streams;
+}
+
+std::size_t MediaFile::streams_number() const
+{
+    return FormatCtx->nb_streams;
+}
+
+AVStream **MediaFile::best_stream(AVMediaType type)
+{
+    int idx = av_find_best_stream(FormatCtx, type, -1, -1, nullptr, 0);
+    return (idx < 0) ? end() : (FormatCtx->streams + idx);
+
+}

--- a/extra/media_processor/media_file.hpp
+++ b/extra/media_processor/media_file.hpp
@@ -1,0 +1,62 @@
+#ifndef media_file_hpp_INCLUDED
+#define media_file_hpp_INCLUDED
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+class StreamProcessor;
+class ProgressTracker;
+
+class MediaFile
+{
+
+    friend class MediaProcessor;
+    
+    AVFormatContext *FormatCtx;
+
+public:
+    MediaFile(const char *filename);
+    MediaFile(const std::string &filename);
+
+    ~MediaFile();
+
+    AVStream **begin();
+
+    AVStream **end();
+
+    std::size_t streams_number() const;
+
+    AVStream **best_stream(AVMediaType type);
+
+    template <class OutputIterator>
+    OutputIterator audio_streams(OutputIterator out)
+    {
+        return streams_of_type(AVMEDIA_TYPE_AUDIO, out);
+    }
+
+    template <class OutputIterator>
+    OutputIterator video_streams(OutputIterator out)
+    {
+        return streams_of_type(AVMEDIA_TYPE_VIDEO, out);
+    }
+
+
+private:
+
+    template <class OutputIterator>
+    OutputIterator streams_of_type(enum AVMediaType type, OutputIterator out)
+    {
+        return std::copy_if(begin(), end(), out, [type] (AVStream *stream) {
+                            return stream->codecpar->codec_type == type;
+        });
+    }
+};
+
+#endif // media_file_hpp_INCLUDED
+

--- a/extra/media_processor/media_processor.cpp
+++ b/extra/media_processor/media_processor.cpp
@@ -1,0 +1,72 @@
+#include "media_processor.hpp"
+
+#include "media_file.hpp"
+#include "stream_processor.hpp"
+
+#include <algorithm>
+
+MediaProcessor::MediaProcessor(MediaFile &media) :
+    Media(media)
+{
+    streamsNumber = std::distance(Media.begin(), Media.end());
+    Processors = new StreamProcessors[streamsNumber];
+}
+
+MediaProcessor::~MediaProcessor()
+{
+    delete[] Processors;
+}
+
+bool MediaProcessor::pushStreamProcessor(StreamProcessor *proc)
+{
+    auto streamIndex = proc->stream()->index;
+    if(streamIndex >= streamsNumber)
+    {
+        return false;
+    }
+    else
+    {
+        Processors[streamIndex].push_back(proc);
+        return true;
+    }
+}
+
+void MediaProcessor::startProcessing(ProgressTracker *tracker)
+{
+    AVPacket pkt;
+    av_init_packet(&pkt);
+    pkt.data = nullptr;
+    pkt.size = 0;
+
+    int64_t length = 0;
+    if(Media.FormatCtx->pb && tracker)
+    {
+        length = avio_size(Media.FormatCtx->pb);
+        tracker->progress(0, length);
+    }
+
+    while(av_read_frame(Media.FormatCtx, &pkt) >= 0)
+    {
+        for(auto &processor : Processors[pkt.stream_index])
+        {
+            processor->push_packet(pkt);
+        }
+        av_packet_unref(&pkt);
+        if(Media.FormatCtx->pb && tracker)
+        {
+            tracker->progress(Media.FormatCtx->pb->pos, length);
+        }
+    }
+    // Notify the processors that processing has finished
+    std::for_each(Processors, Processors + streamsNumber, [] (StreamProcessors &procs)
+    {
+        for(auto &proc : procs)
+        {
+            proc->processing_finished();
+        }
+    });
+    if(Media.FormatCtx->pb && tracker)
+    {
+        tracker->progress(Media.FormatCtx->pb->pos, length);
+    }
+}

--- a/extra/media_processor/media_processor.hpp
+++ b/extra/media_processor/media_processor.hpp
@@ -1,0 +1,55 @@
+#ifndef media_processor_hpp_INCLUDED
+#define media_processor_hpp_INCLUDED
+
+#include <vector>
+
+class StreamProcessor;
+class ProgressTracker;
+class MediaFile;
+
+class MediaProcessor
+{
+    using StreamProcessors = std::vector<StreamProcessor*>;
+
+    template <class SP, class... SPs>
+    struct StreamProcessorPusher
+    {
+        static bool push(MediaProcessor &p, SP *proc, SPs*... procs)
+        {
+            return p.pushStreamProcessor(proc) && StreamProcessorPusher<SPs...>::push(p, procs...);
+        }
+    };
+
+    template <class SP>
+    struct StreamProcessorPusher<SP>
+    {
+        static bool push(MediaProcessor &p, SP *proc)
+        {
+            return p.pushStreamProcessor(proc);
+        }
+    };
+
+    MediaFile &Media;
+    int streamsNumber;
+    StreamProcessors *Processors;
+
+public:
+    MediaProcessor(MediaFile &media);
+    ~MediaProcessor();
+
+
+    template <class SP, class... SPs>
+    bool addStreamProcessors(SP *proc, SPs *... procs)
+    {
+        return StreamProcessorPusher<SP, SPs...>::push(*this, proc, procs...);
+    }
+
+    void startProcessing(ProgressTracker *tracker = nullptr);
+
+private:
+    bool pushStreamProcessor(StreamProcessor *proc);
+};
+
+
+#endif // media_processor_hpp_INCLUDED
+

--- a/extra/media_processor/peak_extractor.cpp
+++ b/extra/media_processor/peak_extractor.cpp
@@ -1,0 +1,179 @@
+#include "peak_extractor.hpp"
+#include "ffmpeg_error.hpp"
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libswresample/swresample.h>
+}
+
+
+#include <iostream>
+#include <algorithm>
+
+PeakExtractor::PeakExtractor(AVStream *stream, int samplesPerPeak) :
+    StreamDecoder(stream),
+    Resampler(nullptr)
+{
+    SamplesBuffer = nullptr;
+    MaxSamples = -1;
+    SamplesPerPeak = samplesPerPeak;
+    SamplesRead = 0;
+
+    if(CodecCtx->sample_fmt != AV_SAMPLE_FMT_S16)
+    {
+        if(Stream->codecpar->channel_layout == 0)
+        {
+            throw FFmpegError("Could not determine input file channel layout");
+        }
+        // We need to resample
+        Resampler = swr_alloc_set_opts(Resampler,
+                                       AV_CH_LAYOUT_MONO,
+                                       AV_SAMPLE_FMT_S16,
+                                       CodecCtx->sample_rate,
+                                       Stream->codecpar->channel_layout,
+                                       CodecCtx->sample_fmt,
+                                       CodecCtx->sample_rate,
+                                       0,
+                                       nullptr);
+        if(!Resampler)
+        {
+            throw FFmpegError("Could not create the resampler");
+        }
+
+        int ret = swr_init(Resampler);
+        if(ret < 0)
+        {
+            throw FFmpegError(ret);
+        }
+
+        Frame = av_frame_alloc();
+        if(!Frame)
+        {
+            throw FFmpegError("Could not allocate frame");
+        }
+    }
+}
+
+PeakExtractor::~PeakExtractor()
+{
+    av_freep(&SamplesBuffer);
+    av_frame_free(&Frame);
+    swr_free(&Resampler);
+}
+
+void PeakExtractor::push_packet(const AVPacket &pkt)
+{
+    int res = avcodec_send_packet(CodecCtx, &pkt);
+
+    if(res == AVERROR_EOF)
+    {
+        std::cout << "Done" << std::endl;
+    }
+    else if(res == AVERROR(EINVAL))
+    {
+        throw FFmpegError(res);
+    }
+
+    processFrames();
+}
+
+void PeakExtractor::processing_finished()
+{
+    // Let's flush the decoder
+    avcodec_send_packet(CodecCtx, nullptr);
+
+    processFrames();
+
+    // Flush resampler
+    int samplesConverted;
+    while((samplesConverted = swr_convert(Resampler, &SamplesBuffer, MaxSamples, nullptr, 0)) > 0)
+    {
+        std::cout << "Flushing resampler" << std::endl;
+        processSamples(samplesConverted);
+    }
+
+    normalizePeaks();
+}
+
+void PeakExtractor::processFrames()
+{
+    int samples = -1;
+    int samplesConverted;
+    // Ok
+    while(avcodec_receive_frame(CodecCtx, Frame) == 0)
+    {
+        samples = swr_get_out_samples(Resampler, Frame->nb_samples);
+        if(samples > MaxSamples)
+        {
+            av_freep(&SamplesBuffer);
+            av_samples_alloc(&SamplesBuffer, nullptr, 1, samples, AV_SAMPLE_FMT_S16, 0);
+            MaxSamples = samples;
+        }
+        samplesConverted = swr_convert(Resampler, &SamplesBuffer, MaxSamples, (const uint8_t**)Frame->data, Frame->nb_samples);
+        if(samplesConverted < 0)
+        {
+            throw FFmpegError(samplesConverted);
+        }
+        else
+        {
+            processSamples(samplesConverted);
+        }
+    }
+}
+
+void PeakExtractor::processSamples(int samplesNumber)
+{
+    int16_t *samples = (int16_t*)SamplesBuffer;
+    int16_t *samplesEnd = samples + samplesNumber;
+    while(samples != samplesEnd) 
+    {
+        if(SamplesRead % SamplesPerPeak != 0)
+        {
+            if(Peaks.back().Max < *samples)
+            {
+                Peaks.back().Max = *samples;
+            }
+            else if(Peaks.back().Min > *samples)
+            {
+                Peaks.back().Min = *samples;
+            }
+            ++samples;
+            ++SamplesRead;
+        }
+        else
+        {
+            Peaks.push_back({*samples, *samples});
+            ++samples;
+            ++SamplesRead;
+        }
+    }
+}
+
+void PeakExtractor::normalizePeaks()
+{
+    int MinPeak = Peaks[0].Min;
+    int MaxPeak = Peaks[0].Max;
+    std::for_each(Peaks.begin() + 1, Peaks.end(), [&MinPeak, &MaxPeak](const Peak &p)
+    {
+        if(p.Min < MinPeak) MinPeak = p.Min;
+        else if(p.Max > MaxPeak) MaxPeak = p.Max;
+    });
+
+    int MaxAbsValue = std::max(std::abs(MinPeak), std::abs(MaxPeak));
+
+    double NormFactor = 32768.0 / MaxAbsValue;
+
+    std::cout << "Norm factor: " << NormFactor << std::endl;
+
+    if(NormFactor > 1.1)
+    {
+        // Apply norm factor
+        for(auto &peak : Peaks)
+        {
+            peak.Max = std::round(peak.Max * NormFactor);
+            peak.Min = std::round(peak.Min * NormFactor);
+        }
+    }
+}

--- a/extra/media_processor/peak_extractor.hpp
+++ b/extra/media_processor/peak_extractor.hpp
@@ -1,0 +1,57 @@
+#ifndef peak_extractor_hpp_INCLUDED
+#define peak_extractor_hpp_INCLUDED
+
+#include "stream_processor.hpp"
+#include <vector>
+
+struct SwrContext;
+struct AVFrame;
+
+struct Peak
+{
+    int16_t Min;
+    int16_t Max;
+};
+
+class PeakExtractor : public StreamDecoder
+{
+    SwrContext *Resampler;
+    AVFrame *Frame;
+
+    uint8_t *SamplesBuffer;
+    int MaxSamples;
+
+    int SamplesPerPeak;
+    int SamplesRead;
+
+    std::vector<Peak> Peaks;
+public:
+    using Format = int16_t;
+    
+    PeakExtractor(AVStream *stream, int samplesPerPeak);
+
+    virtual ~PeakExtractor();
+
+    virtual void push_packet(const AVPacket &pkt) override;
+    virtual void processing_finished() override;
+
+    const std::vector<Peak> &peaks() const
+    {
+        return Peaks;
+    }
+
+    std::vector<Peak> &peaks()
+    {
+        return Peaks;
+    }
+
+private: 
+    void processFrames();
+
+    void processSamples(int samplesNumber);
+
+    void normalizePeaks();
+};
+
+#endif // peak_extractor_hpp_INCLUDED
+

--- a/extra/media_processor/stream_processor.cpp
+++ b/extra/media_processor/stream_processor.cpp
@@ -1,0 +1,43 @@
+#include "stream_processor.hpp"
+#include "ffmpeg_error.hpp"
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+}
+
+
+StreamProcessor::~StreamProcessor() { }
+
+StreamDecoder::StreamDecoder(AVStream *stream) :
+    StreamProcessor(stream)
+{
+    AVCodecParameters *parameters = Stream->codecpar;
+    Codec = avcodec_find_decoder(parameters->codec_id);
+    if(!Codec)
+    {
+        throw FFmpegError("Could not find codec");
+    }
+
+    CodecCtx = avcodec_alloc_context3(Codec);
+    if(!CodecCtx)
+    {
+        throw FFmpegError("Could not allocate decoder");
+    }
+
+    if(avcodec_parameters_to_context(CodecCtx, parameters) < 0)
+    {
+        throw FFmpegError("Could not copy decoder data");
+    }
+
+    if(avcodec_open2(CodecCtx, Codec, nullptr) < 0)
+    {
+        throw FFmpegError("Error while opening decoder");
+    }
+}
+
+StreamDecoder::~StreamDecoder()
+{
+    avcodec_free_context(&CodecCtx);
+}

--- a/extra/media_processor/stream_processor.hpp
+++ b/extra/media_processor/stream_processor.hpp
@@ -1,0 +1,62 @@
+#ifndef stream_processor_hpp_INCLUDED
+#define stream_processor_hpp_INCLUDED
+
+#include <cstdint>
+
+using std::int64_t;
+
+struct AVPacket;
+struct AVCodecContext;
+struct AVCodec;
+struct AVStream;
+struct AVDictionary;
+
+struct ProgressTracker
+{
+    virtual void progress(int64_t curr, int64_t total) = 0;
+};
+
+struct StreamProcessor
+{
+protected:
+    AVStream *Stream;
+
+public:
+    StreamProcessor(AVStream *stream) :
+        Stream(stream)
+    { }
+
+    virtual ~StreamProcessor();
+    virtual void push_packet(const AVPacket &pkt) = 0;
+
+    // Useful for doing things like flushing
+    // By default, it does nothing
+    virtual void processing_finished() { }
+
+    StreamProcessor(const StreamProcessor &other) = delete;
+    StreamProcessor(StreamProcessor &&other) = delete;
+
+    void operator=(const StreamProcessor &other) = delete;
+
+    const AVStream *stream() const
+    {
+        return Stream;
+    }
+
+};
+
+class StreamDecoder : public StreamProcessor
+{
+protected:
+    AVCodecContext *CodecCtx;
+    AVCodec *Codec;
+
+public:
+    StreamDecoder(AVStream *stream);
+
+    virtual ~StreamDecoder();
+
+};
+
+#endif // stream_processor_hpp_INCLUDED
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Do Androids dream of electron sheeps",
   "main": "app/main.js",
   "scripts": {
-    "build": "tsc",
+    "build": "(cd extra && make) && tsc",
     "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,15 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
+
+const {ipcRenderer} = require('electron')
+
+const {spawn} = require('child_process')
+
+const {prova} = require('./prova')
+
+console.log(ipcRenderer.sendSync('extract-peaks', 
+    {
+        media: '/home/francesco/Desktop/Pushing.Daisies.S01.576p.BluRay.DD5.1.x264-HiSD/Pushing.Daisies.S01E01.576p.BluRay.DD5.1.x264-HiSD.mkv',
+        out: '/home/francesco/output_peaks'
+    }))

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,12 +4,7 @@
 
 const {ipcRenderer} = require('electron')
 
-const {spawn} = require('child_process')
+ipcRenderer.on('extraction-finished', (event, exit_code) => {
+    console.log(`Finished ${exit_code}`)
+});
 
-const {prova} = require('./prova')
-
-console.log(ipcRenderer.sendSync('extract-peaks', 
-    {
-        media: '/home/francesco/Desktop/Pushing.Daisies.S01.576p.BluRay.DD5.1.x264-HiSD/Pushing.Daisies.S01E01.576p.BluRay.DD5.1.x264-HiSD.mkv',
-        out: '/home/francesco/output_peaks'
-    }))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
-import { app, Menu, BrowserWindow} from 'electron';
+import { app, Menu, BrowserWindow, ipcMain } from 'electron';
 import { MenuTemplate } from './menu/menu_template';
 import { devMenuTemplate } from './menu/dev_menu_template';
 import * as path from 'path';
 import * as url from 'url';
+
+import { spawnSync } from 'child_process';
 
 // Special module holding environment variables
 import env from './env';
@@ -64,6 +66,19 @@ app.on('activate', function () {
 	if (mainWindow === null) {
 		createWindow()
 	}
+})
+
+ipcMain.on('extract-peaks', (event, arg) => {
+        let res = spawnSync('./extra/pex', [arg.media, arg.out])
+        if(res.status == 0) {
+            event.returnValue = 'Yeah'
+        }
+        else if(res.status == 2) {
+            event.returnValue = 'No audio'
+        }
+        else {
+            event.returnValue = 'Nay'
+        }
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,6 @@ import { devMenuTemplate } from './menu/dev_menu_template';
 import * as path from 'path';
 import * as url from 'url';
 
-import { spawnSync } from 'child_process';
-
 // Special module holding environment variables
 import env from './env';
 
@@ -66,19 +64,6 @@ app.on('activate', function () {
 	if (mainWindow === null) {
 		createWindow()
 	}
-})
-
-ipcMain.on('extract-peaks', (event, arg) => {
-        let res = spawnSync('./extra/pex', [arg.media, arg.out])
-        if(res.status == 0) {
-            event.returnValue = 'Yeah'
-        }
-        else if(res.status == 2) {
-            event.returnValue = 'No audio'
-        }
-        else {
-            event.returnValue = 'Nay'
-        }
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/src/menu/menu_template.ts
+++ b/src/menu/menu_template.ts
@@ -1,4 +1,6 @@
-import {BrowserWindow, dialog} from 'electron';
+import { BrowserWindow, dialog, ipcMain } from 'electron';
+
+import { spawn } from 'child_process';
 
 export var MenuTemplate = {
     label: 'File',
@@ -15,7 +17,14 @@ export var MenuTemplate = {
                     ]
                 }
                 let parentWindow = (process.platform == 'darwin') ? null : BrowserWindow.getFocusedWindow();
-                dialog.showOpenDialog(parentWindow, options, function (f) { console.log("got a file: " + f) });
+                dialog.showOpenDialog(parentWindow, options, function (f) {
+                    console.log("got a file: " + f)
+
+                    let extractor = spawn('extra/pex', [f[0], './output_peaks']);
+                    extractor.on('close', (code) => {
+                            parentWindow.webContents.send('extraction-finished', code);
+                    });
+                });
             }
         }
     ]


### PR DESCRIPTION
I wrote a small demo:
When opening a new video from the menu, the external program pex (peak extractor) gets called and extracts peaks from that video and saves them in ./output_peaks
When it's done it sends a message to the renderer process which prints an output message with the exit status.

pex is in extra/ and in extra/media_processor there is its source code. It's written in C++ using ffmpeg libriaries to extract data.

It's still a WIP  because before merging we should prove that performances are acceptable, we should also consider other possibilities and finally we should see whether this approach proves flexible enough for our uses:
We'd also like to get the percentage of the process and possibly we should also recognize the scene changes in the video (the code for this last thing is already there and should be working)

Other ways I can think of are:
- Write a module for nodejs in C++ to interface directly with the code we're using 
- Find an npm module
 
For now I didn't find anything useful on npm.

Related to #3 